### PR TITLE
User definable context keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = {
       name: options.name,
 
       contextKeys: {
-        revision: 'revision'
+        revision: 'tag'
       },
 
       configure: function(context) {
@@ -60,17 +60,7 @@ module.exports = {
         var config      = deployment.config[this.name] = deployment.config[this.name] || {};
         var projectName = deployment.project.name();
 
-        Object.keys(this.contextKeys).forEach(function(key) {
-          var value = config[key];
-
-          if (value) {
-            var newValue = value.match(/(\$context:)(.*)/)[2];
-
-            if (newValue) {
-              this.contextKeys[key] = newValue;
-            }
-          }
-        }.bind(this));
+        this._setUserDefinedContextKeys(config);
 
         return validateConfig(ui, config, projectName)
           .then(function() {
@@ -108,6 +98,21 @@ module.exports = {
         }.bind(this));
 
         return result;
+      },
+
+      _setUserDefinedContextKeys: function(config) {
+        var regex = /(\$context:)(.*)/;
+        Object.keys(this.contextKeys).forEach(function(key) {
+          var value = config[key];
+
+          if (value) {
+            var newValue = value.match(regex)[2];
+
+            if (newValue) {
+              this.contextKeys[key] = newValue;
+            }
+          }
+        }.bind(this));
       }
     };
   }


### PR DESCRIPTION
This PR allows: 
- a plugin to specify which keys it will be accessing from the `context` object and then and;
- a user to override the context keys if they would like the plugin to retrieve data from some other value on the `context` object.

To do this, a plugin can define a `contextKeys` hash like so:

```javascript
return {
  name: options.name,

  contextKeys: {
    revision: 'revision'
  }
}
```

This means that the plugin will be using a `revision` property at some stage in the lifecycle and it will retrieve it from `context.revision`.

However, a user might have written their own plugin that puts some sort of revision string under a different property on the `context` object, say, `context.tag`.  In this case, the user can specify in their `deploy.js` file that they would like the redis plugin to use the new property for it's revision, like so:

```javascript
module.exports = function(environment) {
  var ENV = {
    redis: {
      revision: '$context:tag'
    }
  };

  return ENV;
}
```

The redis plugin will inspect the config looking for anything that starts with `$context:` and the value to override the `contextKeys` that it will use.  Now, when the redis plugin is looking for the revision it will look in `context.tag` instead of `context.revision`