### PR TITLE
Added didDeploy hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,23 @@ module.exports = {
 
         return _beginActivateMessage(ui, revisionKey)
           .then(redis.activate.bind(redis, config.keyPrefix, revisionKey))
+          .then(function(){
+            context.activatedRevisionKey = revisionKey;
+          })
           .then(_activationSuccessMessage.bind(this, ui, revisionKey))
           .catch(_errorMessage.bind(this, ui));
+      },
+
+      didDeploy: function(context){
+        var deployment  = context.deployment;
+        var ui          = deployment.ui;
+        var config      = deployment.config[this.name] || {};
+        var didDeployMessage = this._resolveConfigValue('didDeployMessage', config, context);
+        if (didDeployMessage) {
+          ui.write(blue('|      '));
+          ui.write(blue(didDeployMessage + '`\n'));
+        }
+        return Promise.resolve();
       },
 
       _resolvePipelineData: function(config, context) {

--- a/lib/utilities/validate-config.js
+++ b/lib/utilities/validate-config.js
@@ -8,6 +8,9 @@ function applyDefaultConfigIfNecessary(config, prop, defaultConfig, ui){
   if (!config[prop]) {
     var value = defaultConfig[prop];
     config[prop] = value;
+    if (typeof value === "function") {
+      value = "[Function]";
+    }
     ui.write(blue('|    '));
     ui.writeLine(yellow('- Missing config: `' + prop + '`, using default: `' + value + '`'));
   }
@@ -21,7 +24,14 @@ module.exports = function(ui, config, projectName) {
     host: 'localhost',
     port: 6379,
     filePattern: 'dist/index.html',
-    keyPrefix: projectName + ':index'
+    keyPrefix: projectName + ':index',
+    didDeployMessage: function(context){
+      if (context.revisionKey && !context.activatedRevisionKey) {
+        return "Deployed but did not activate revision " + context.revisionKey + ". "
+             + "To activate, run: "
+             + "ember activate " + context.revisionKey + " --environment=" + context.deployment.deployEnvironment + "\n";
+      }
+    }
   };
 
   if (!config.url) {
@@ -29,7 +39,7 @@ module.exports = function(ui, config, projectName) {
       applyDefaultConfigIfNecessary(config, prop, defaultConfig, ui);
     });
   }
-  ['filePattern', 'keyPrefix'].forEach(function(configKey){
+  ['filePattern', 'keyPrefix', 'didDeployMessage'].forEach(function(configKey){
     applyDefaultConfigIfNecessary(config, configKey, defaultConfig, ui);
   });
 

--- a/tests/unit/lib/utilities/validate-config-nodetest.js
+++ b/tests/unit/lib/utilities/validate-config-nodetest.js
@@ -34,7 +34,7 @@ describe('validate-config', function() {
 
             return previous;
           }, []);
-          assert.equal(messages.length, 4);
+          assert.equal(messages.length, 5);
         });
     });
 
@@ -44,6 +44,7 @@ describe('validate-config', function() {
           assert.isDefined(config.host);
           assert.isDefined(config.port);
           assert.isDefined(config.keyPrefix);
+          assert.isDefined(config.didDeployMessage);
         });
     });
 
@@ -69,7 +70,7 @@ describe('validate-config', function() {
             return previous;
           }, []);
 
-          assert.equal(messages.length, 3);
+          assert.equal(messages.length, 4);
         });
     });
     it('does not add default config to the config object', function() {
@@ -78,6 +79,7 @@ describe('validate-config', function() {
           assert.isDefined(config.host);
           assert.isDefined(config.port);
           assert.isDefined(config.filePattern);
+          assert.isDefined(config.didDeployMessage);
           assert.equal(config.keyPrefix, 'proj:home');
         });
     });
@@ -89,7 +91,7 @@ describe('validate-config', function() {
         url: 'redis://localhost:6379'
       };
     });
-    it('warns about missing optional filePattern and keyPrefix only', function() {
+    it('warns about missing optional filePattern, keyPrefix and didDeployMessage only', function() {
       return assert.isFulfilled(subject(mockUi, config, projectName))
         .then(function() {
           var messages = mockUi.messages.reduce(function(previous, current) {
@@ -100,7 +102,7 @@ describe('validate-config', function() {
             return previous;
           }, []);
 
-          assert.equal(messages.length, 2);
+          assert.equal(messages.length, 3);
         });
     });
 
@@ -110,6 +112,7 @@ describe('validate-config', function() {
           assert.isUndefined(config.host);
           assert.isUndefined(config.port);
           assert.isDefined(config.filePattern);
+          assert.isDefined(config.didDeployMessage);
         });
     });
 


### PR DESCRIPTION
Added `didDeploy` hook, and make activate hook add `activatedRevisionKey` to context.

The didDeploy hook works with a configurable `didDeployMessage` which is output
when the hook runs.

Note that this relies on https://github.com/ember-cli/ember-cli-deploy/pull/174 being merged for default implementation of `didDeployMessage` to work properly.

This new feature allows outputting a preview URL, which cannot be part of the default implementation because it requires knowledge of server implementation. For example, a potential excerpt from `config/deploy.js`:

```js
   ENV.redis.didDeployMessage = function(context) {
      if (context.revisionKey && !context.activatedRevisionKey) {
        return "Deployed but did not activate revision " + context.revisionKey + ".\n"
             + "To preview:\n"
             + "https://" + domain + "/apps/?manifest_id=" + context.revisionKey + "\n"
             + "To activate:\n"
             + "ember activate " + context.revisionKey + " --environment=" + context.deployment.deployEnvironment + "\n";
      }
    }
```