### PR TITLE
Read config from configured name path instead of static 'redis' key

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ module.exports = {
           return context.commandOptions.revision || context.revisionKey;
         },
         redisDeployClient: function(context) {
-          var options = context.config.redis;
+          var redisOptions = this.pluginConfig;
           var redisLib = context._redisLib;
 
-          return new Redis(options, redisLib);
+          return new Redis(redisOptions, redisLib);
         }
       },
       configure: function(/* context */) {
@@ -114,6 +114,7 @@ module.exports = {
         return Promise.reject(error);
       }
     });
+
     return new DeployPlugin();
   }
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "core-object": "^1.1.0",
-    "ember-cli-deploy-plugin": "0.1.2",
+    "ember-cli-deploy-plugin": "0.1.3",
     "ember-cli-babel": "^5.0.0",
     "redis": "^0.12.1",
     "rsvp": "^3.0.18",

--- a/tests/helpers/fake-redis-client.js
+++ b/tests/helpers/fake-redis-client.js
@@ -1,0 +1,13 @@
+var CoreObject = require('core-object');
+
+module.exports = CoreObject.extend({
+  init: function (options) {
+    this.options = options;
+  },
+  get: function(key) {
+    return Promise.resolve('some-other-value');
+  },
+  set: function() { },
+  lpush: function() { },
+  ltrim: function() { }
+});

--- a/tests/helpers/fake-redis-lib.js
+++ b/tests/helpers/fake-redis-lib.js
@@ -1,0 +1,15 @@
+var FakeClient = require('./fake-redis-client');
+
+var CoreObject = require('core-object');
+
+module.exports = CoreObject.extend({
+  init: function(clientClass) {
+      this.clientClass = clientClass || FakeClient;
+  },
+
+  createClient: function(options) {
+    this.options = options;
+    this.createdClient = new this.clientClass(options);
+    return this.createdClient;
+  }
+});

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var FakeRedis = require('../../helpers/fake-redis-lib');
+var FakeClient = require('../../helpers/fake-redis-client');
+
+
 var Promise = require('ember-cli/lib/ext/promise');
 var assert  = require('ember-cli/tests/helpers/assert');
 var CoreObject = require('core-object');
@@ -9,26 +13,6 @@ describe('redis', function() {
 
   before(function() {
     Redis = require('../../../lib/redis');
-  });
-
-  var FakeClient = CoreObject.extend({
-    get: function(key) {
-      return Promise.resolve('some-other-value');
-    },
-    set: function() { },
-    lpush: function() { },
-    ltrim: function() { }
-  });
-
-  var FakeRedis = CoreObject.extend({
-    init: function(clientClass) {
-        this.clientClass = clientClass || FakeClient;
-    },
-
-    createClient: function(options) {
-      this.options = options;
-      return new this.clientClass()
-    }
   });
 
   describe('#upload', function() {


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli-deploy/pull/195 has landed and I added tests.

So this is good to go from my POV.
