### PR TITLE
add fetchRevisions to lib/redis and deployPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,18 @@ module.exports = {
         }
       },
 
+      fetchRevisions: function(context) {
+        var redisDeployClient = this.readConfig('redisDeployClient');
+        var keyPrefix = this.readConfig('keyPrefix');
+
+        this.log('Listing revisions for key: `' + keyPrefix + '`');
+        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
+          .then(function(revisions){
+            return { revisions: revisions };
+          })
+          .catch(this._errorMessage.bind(this));
+      },
+
       _readFileContents: function(path) {
         return readFile(path)
           .then(function(buffer) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -61,6 +61,22 @@ module.exports = CoreObject.extend({
       .then(this._activateRevisionKey.bind(this, currentKey, revisionKey));
   },
 
+  fetchRevisions: function(keyPrefix) {
+    var currentKey = keyPrefix + ':current';
+
+    return Promise.hash({
+      revisions: this._listRevisions(keyPrefix),
+      current: this._client.get(currentKey)
+    }).then(function(results) {
+        return results.revisions.map(function(revision) {
+          return {
+            revision: revision,
+            active: revision === results.current
+          };
+        });
+      });
+  },
+
   _listRevisions: function(keyPrefix) {
     var client = this._client;
     return client.lrange(keyPrefix, 0, this._maxNumberOfRecentUploads - 1);

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -178,4 +178,68 @@ describe('redis', function() {
         });
     });
   });
+
+  describe('#fetchRevisions', function() {
+    it('lists the last existing revisions', function() {
+      var recentRevisions = ['a', 'b', 'c'];
+
+      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
+        lrange: function() {
+          return recentRevisions;
+        },
+        get: function() {
+        }
+      })));
+
+      var promise = redis.fetchRevisions('key-prefix');
+      return assert.isFulfilled(promise)
+        .then(function(result) {
+          assert.deepEqual(result, [
+            {
+              revision: 'a',
+              active: false
+            },
+            {
+              revision: 'b',
+              active: false
+            },
+            {
+              revision: 'c',
+              active: false
+            }
+          ]
+        );
+      });
+    });
+
+    it('lists revisions and marks the active one', function() {
+      var recentRevisions = ['a', 'b'];
+      var currentRevision = 'b';
+
+      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
+        lrange: function() {
+          return recentRevisions;
+        },
+        get: function() {
+          return currentRevision;
+        }
+      })));
+
+      var promise = redis.fetchRevisions('key-prefix');
+      return assert.isFulfilled(promise)
+        .then(function(result) {
+          assert.deepEqual(result, [
+            {
+              revision: 'a',
+              active: false
+            },
+            {
+              revision: 'b',
+              active: true
+            }
+          ]
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
as discussed on chat,
this implements the fetchRevisions hook for this plugin

used by https://github.com/duizendnegen/ember-cli-deploy-display-revisions to support
`ember deploy:list <env>`

currently missing (and I think these could be added later)

* [ ] support for specifying the number of revisions we want to list
* [ ] timestamp for the revision
* [ ] deployer for the revision

please let me know if this seems and/or what should I tweak, thanks!

/cc @achambers @lukemelia 

