### PR TITLE
use a sorted set to store the list of revisions

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -79,7 +79,7 @@ module.exports = CoreObject.extend({
 
   _listRevisions: function(keyPrefix) {
     var client = this._client;
-    return client.lrange(keyPrefix, 0, this._maxNumberOfRecentUploads - 1);
+    return client.zrevrange(keyPrefix, 0, -1);
   },
 
   _validateRevisionKey: function(revisionKey, revisions) {
@@ -111,11 +111,12 @@ module.exports = CoreObject.extend({
 
   _updateRecentUploadsList: function(keyPrefix, revisionKey) {
     var client = this._client;
-    return client.lpush(keyPrefix, revisionKey);
+    var score = new Date().getTime();
+    return client.zadd(keyPrefix, score, revisionKey);
   },
 
   _trimRecentUploadsList: function(keyPrefix, maxEntries) {
     var client = this._client;
-    return client.ltrim(keyPrefix, 0, maxEntries - 1);
+    return client.zremrangebyrank(keyPrefix, 0, -(maxEntries + 1));
   }
 });

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -62,11 +62,9 @@ module.exports = CoreObject.extend({
   },
 
   fetchRevisions: function(keyPrefix) {
-    var currentKey = keyPrefix + ':current';
-
     return Promise.hash({
       revisions: this._listRevisions(keyPrefix),
-      current: this._client.get(currentKey)
+      current: this._activeRevision(keyPrefix)
     }).then(function(results) {
         return results.revisions.map(function(revision) {
           return {
@@ -106,7 +104,7 @@ module.exports = CoreObject.extend({
       })
       .then(function() {
         return client.set(redisKey, value);
-      })
+      });
   },
 
   _updateRecentUploadsList: function(keyPrefix, revisionKey) {
@@ -115,8 +113,29 @@ module.exports = CoreObject.extend({
     return client.zadd(keyPrefix, score, revisionKey);
   },
 
+  _activeRevision: function(keyPrefix) {
+    var currentKey = keyPrefix + ':current';
+    return this._client.get(currentKey);
+  },
+
   _trimRecentUploadsList: function(keyPrefix, maxEntries) {
     var client = this._client;
-    return client.zremrangebyrank(keyPrefix, 0, -(maxEntries + 1));
+
+    return Promise.hash({
+      revisionsToBeRemoved: client.zrange(keyPrefix, 0, -(maxEntries + 1)),
+      current: this._activeRevision(keyPrefix)
+    }).then(function(results) {
+      var revisions = results.revisionsToBeRemoved;
+      var current = results.current;
+      if (!revisions) {
+        return;
+      }
+      revisions.forEach(function(revision) {
+        if (revision !== current) {
+          client.del(keyPrefix + ":" + revision);
+          client.zrem(keyPrefix, revision);
+        }
+      });
+    });
   }
 });

--- a/tests/helpers/fake-redis-client.js
+++ b/tests/helpers/fake-redis-client.js
@@ -8,6 +8,13 @@ module.exports = CoreObject.extend({
     return Promise.resolve('some-other-value');
   },
   set: function() { },
-  lpush: function() { },
-  ltrim: function() { }
+  del: function() { },
+  zadd: function(key, score, tag) {
+  },
+  zrem: function() {
+  },
+  zrange: function() {
+  },
+  zrevrange: function() {
+  }
 });

--- a/tests/helpers/fake-redis-client.js
+++ b/tests/helpers/fake-redis-client.js
@@ -2,6 +2,7 @@ var CoreObject = require('core-object');
 
 module.exports = CoreObject.extend({
   init: function (options) {
+    this.recentRevisions = [];
     this.options = options;
   },
   get: function(key) {
@@ -9,12 +10,16 @@ module.exports = CoreObject.extend({
   },
   set: function() { },
   del: function() { },
-  zadd: function(key, score, tag) {
+  zadd: function(key, score , tag) {
+    this.recentRevisions.push(key + ':' + tag);
   },
-  zrem: function() {
+  zrem: function(val,revision) {
+    var i = this.recentRevisions.indexOf(revision)
+    this.recentRevisions.splice(i,1);
   },
   zrange: function() {
   },
   zrevrange: function() {
+    return this.recentRevisions;
   }
 });

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -194,7 +194,7 @@ describe('redis', function() {
       var recentRevisions = ['a', 'b', 'c'];
 
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        lrange: function() {
+        zrevrange: function() {
           return recentRevisions;
         },
         get: function() {
@@ -227,7 +227,7 @@ describe('redis', function() {
       var currentRevision = 'b';
 
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        lrange: function() {
+        zrevrange: function() {
           return recentRevisions;
         },
         get: function() {

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -32,6 +32,10 @@ describe('redis', function() {
         },
         set: function(key, value) {
           fileUploaded = true;
+        },
+        zadd: function(key, score, tag) {
+        },
+        zremrangebyrank: function() {
         }
       })));
 
@@ -50,6 +54,10 @@ describe('redis', function() {
       }, new FakeRedis(FakeClient.extend({
         set: function(key, value) {
           fileUploaded = true;
+        },
+        zadd: function(key, score, tag) {
+        },
+        zremrangebyrank: function() {
         }
       })));
 
@@ -67,9 +75,11 @@ describe('redis', function() {
         get: function(key) {
           return Promise.resolve(null);
         },
-        lpush: function(key, tag) {
+        zadd: function(key, score , tag) {
           recentUploads.push(key + tag);
         },
+        zremrangebyrank: function() {
+        }
       })));
 
       var promise = redis.upload('key', 'value');
@@ -87,10 +97,10 @@ describe('redis', function() {
         get: function(key) {
           return Promise.resolve(null);
         },
-        lpush: function(key, tag) {
+        zadd: function(key, tag) {
           recentUploads.push(key + tag);
         },
-        ltrim: function() {
+        zremrangebyrank: function() {
           recentUploads.pop();
         }
       })));
@@ -143,7 +153,7 @@ describe('redis', function() {
       var recentRevisions = ['a', 'b', 'c'];
 
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        lrange: function() {
+        zrevrange: function() {
           return recentRevisions;
         }
       })));
@@ -161,7 +171,7 @@ describe('redis', function() {
 
 
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        lrange: function() {
+        zrevrange: function() {
           return recentRevisions;
         },
         set: function(key, value) {


### PR DESCRIPTION
as discussed with @achambers and @lukemelia the idea here is to use a sorted set to store the list of deployed revisions

this way if a user has allowOverwrite: true in the config the key is not added twice
instead the score for the key in the set (timestamp) is updated

note also that this will be a breaking change with the current 0.5.0 installs
p.s.

Haven't had time to investigate further but we also had to stub more methods then before in the tests (zadd, zremrangebyrank) 


/cc @elucid 